### PR TITLE
Fix the issue with pop up window spinner

### DIFF
--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SettingsFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SettingsFragment.java
@@ -235,7 +235,8 @@ public class SettingsFragment extends Fragment {
               LayoutInflater inflater =
                   (LayoutInflater)
                       getActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-              View layout = inflater.inflate(R.layout.pop_up_window, null);
+              View layout = inflater.inflate(R.layout.pop_up_window,
+                      (ViewGroup) getActivity().findViewById(R.id.pop));
 
               // Find UI elements in pop up window
               final Spinner residualSpinner = layout.findViewById(R.id.residual_spinner);

--- a/GNSSLogger/app/src/main/res/layout/pop_up_window.xml
+++ b/GNSSLogger/app/src/main/res/layout/pop_up_window.xml
@@ -26,7 +26,8 @@
           android:layout_height="wrap_content"
           android:gravity="end"
           android:id="@+id/residual_spinner"
-          android:entries="@array/residual_options">
+          android:entries="@array/residual_options"
+          android:spinnerMode="dialog">
       </Spinner>
     </LinearLayout>
     <EditText


### PR DESCRIPTION
Fix the bug causing GnssLogger to crash when opening the spinner inside residual mode settings.
