### PR TITLE
NullPointerException on Google Play disable

### DIFF
--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/MapFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/MapFragment.java
@@ -155,7 +155,7 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
               mLastLocationMarkerRaw.setPosition(latLngRaw);
               mLastLocationMarkerDevice.setPosition(latLngDevice);
             }
-            if (mLastLocationMarkerRaw == null && mLastLocationMarkerDevice == null) {
+            if (mLastLocationMarkerRaw != null && mLastLocationMarkerDevice != null) {
               String formattedDate = DATE_SDF.format(new Date(timeMillis));
               mLastLocationMarkerRaw.setTitle("time: " + formattedDate);
               mLastLocationMarkerDevice.showInfoWindow();


### PR DESCRIPTION
If Google Play is disable, 
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.gms.maps.model.Marker.setTitle(java.lang.String)' on a null object reference
        at com.google.android.apps.location.gps.gnsslogger.MapFragment$1.run(MapFragment.java:160)

So 
            if (mLastLocationMarkerRaw == null && mLastLocationMarkerDevice == null) {
              ...
              mLastLocationMarkerRaw.setTitle("time: " + formattedDate);
should be
            if (mLastLocationMarkerRaw ！= null && mLastLocationMarkerDevice ！= null) {
              ...
              mLastLocationMarkerRaw.setTitle("time: " + formattedDate);