### PR TITLE
Remove new line characters from NMEA sentences before logging

### DIFF
--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/FileLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/FileLogger.java
@@ -332,7 +332,7 @@ public class FileLogger implements GnssListener {
       if (mFileWriter == null) {
         return;
       }
-      String nmeaStream = String.format(Locale.US, "NMEA,%s,%d", s, timestamp);
+      String nmeaStream = String.format(Locale.US, "NMEA,%s,%d", s.trim(), timestamp);
       try {
         mFileWriter.write(nmeaStream);
         mFileWriter.newLine();


### PR DESCRIPTION
Some devices such as the Samsung Galaxy S8+ (SM-G955U) include a new line character at the end of the NMEA sentence. This extra new line character breaks logging by pushing the timestamp for the NMEA sentence to the following line.  

This patch fixes the problem by trimming off any whitespace from the NMEA sentence before logging it.

On these devices, currently the log file looks like this:

~~~
NMEA,$GPGSV,3,1,10,10,71,021,29,20,61,109,29,25,26,125,30,31,33,212,26,1*6F
,1567814730009
~~~

...and after this patch it looks like this:

~~~
NMEA,$GPGSV,3,1,10,10,71,021,29,20,61,109,29,25,26,125,30,31,33,212,26,1*6F,1567814730009
~~~