### PR TITLE
Add IMU data

### DIFF
--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/AgnssFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/AgnssFragment.java
@@ -39,12 +39,12 @@ public class AgnssFragment extends Fragment {
   public static final String TAG = ":AgnssFragment";
   private TextView mLogView;
   private ScrollView mScrollView;
-  private GnssContainer mGpsContainer;
+  private SensorFusionContainer mGpsContainer;
   private AgnssUiLogger mUiLogger;
 
   private final AgnssUIFragmentComponent mUiComponent = new AgnssUIFragmentComponent();
 
-  public void setGpsContainer(GnssContainer value) {
+  public void setGpsContainer(SensorFusionContainer value) {
     mGpsContainer = value;
   }
 
@@ -68,11 +68,11 @@ public class AgnssFragment extends Fragment {
         new OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.i(GnssContainer.TAG + TAG, "Clearing AGPS");
+            Log.i(SensorFusionContainer.TAG + TAG, "Clearing AGPS");
             LocationManager locationManager = mGpsContainer.getLocationManager();
             locationManager.sendExtraCommand(
                 LocationManager.GPS_PROVIDER, "delete_aiding_data", null);
-            Log.i(GnssContainer.TAG + TAG, "Clearing AGPS command sent");
+            Log.i(SensorFusionContainer.TAG + TAG, "Clearing AGPS command sent");
           }
         });
 
@@ -81,11 +81,11 @@ public class AgnssFragment extends Fragment {
         new OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.i(GnssContainer.TAG + TAG, "Fetching Extra data");
+            Log.i(SensorFusionContainer.TAG + TAG, "Fetching Extra data");
             LocationManager locationManager = mGpsContainer.getLocationManager();
             Bundle bundle = new Bundle();
             locationManager.sendExtraCommand("gps", "force_xtra_injection", bundle);
-            Log.i(GnssContainer.TAG + TAG, "Fetching Extra data Command sent");
+            Log.i(SensorFusionContainer.TAG + TAG, "Fetching Extra data Command sent");
           }
         });
 
@@ -94,11 +94,11 @@ public class AgnssFragment extends Fragment {
         new OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.i(GnssContainer.TAG + TAG, "Fetching Time data");
+            Log.i(SensorFusionContainer.TAG + TAG, "Fetching Time data");
             LocationManager locationManager = mGpsContainer.getLocationManager();
             Bundle bundle = new Bundle();
             locationManager.sendExtraCommand("gps", "force_time_injection", bundle);
-            Log.i(GnssContainer.TAG + TAG, "Fetching Time data Command sent");
+            Log.i(SensorFusionContainer.TAG + TAG, "Fetching Time data Command sent");
           }
         });
 
@@ -107,9 +107,9 @@ public class AgnssFragment extends Fragment {
         new OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.i(GnssContainer.TAG + TAG, "Requesting Single NLP Location");
+            Log.i(SensorFusionContainer.TAG + TAG, "Requesting Single NLP Location");
             mGpsContainer.registerSingleNetworkLocation();
-            Log.i(GnssContainer.TAG + TAG, "Single NLP Location Requested");
+            Log.i(SensorFusionContainer.TAG + TAG, "Single NLP Location Requested");
           }
         });
 
@@ -118,9 +118,9 @@ public class AgnssFragment extends Fragment {
         new OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.i(GnssContainer.TAG + TAG, "Requesting Single GPS Location");
+            Log.i(SensorFusionContainer.TAG + TAG, "Requesting Single GPS Location");
             mGpsContainer.registerSingleGpsLocation();
-            Log.i(GnssContainer.TAG + TAG, "Single GPS Location Requested");
+            Log.i(SensorFusionContainer.TAG + TAG, "Single GPS Location Requested");
           }
         });
     Button clear = (Button) newView.findViewById(R.id.clear_log);

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/AgnssUiLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/AgnssUiLogger.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  * A class representing a UI logger for the application. Its responsibility is show information in
  * the UI.
  */
-public class AgnssUiLogger implements GnssListener {
+public class AgnssUiLogger implements SensorFusionListener {
 
   private static final int USED_COLOR = Color.rgb(0x4a, 0x5f, 0x70);
 
@@ -93,7 +93,7 @@ public class AgnssUiLogger implements GnssListener {
   }
 
   private void logEvent(String tag, String message, int color) {
-    String composedTag = GnssContainer.TAG + tag;
+    String composedTag = SensorFusionContainer.TAG + tag;
     Log.d(composedTag, message);
     logText(tag, message, color);
   }

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/AgnssUiLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/AgnssUiLogger.java
@@ -17,6 +17,7 @@
 package com.google.android.apps.location.gps.gnsslogger;
 
 import android.graphics.Color;
+import android.hardware.SensorEvent;
 import android.location.GnssMeasurementsEvent;
 import android.location.GnssNavigationMessage;
 import android.location.GnssStatus;
@@ -86,6 +87,10 @@ public class AgnssUiLogger implements SensorFusionListener {
 
   @Override
   public void onNmeaReceived(long timestamp, String s) {}
+
+  @Override
+  public void onSensorChanged(SensorEvent event) {
+  }
 
   @Override
   public void onListenerRegistration(String listener, boolean result) {

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/FileLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/FileLogger.java
@@ -49,7 +49,7 @@ import java.util.Locale;
 /**
  * A GNSS logger to store information to a file.
  */
-public class FileLogger implements GnssListener {
+public class FileLogger implements SensorFusionListener {
 
   private static final String TAG = "FileLogger";
   private static final String FILE_PREFIX = "gnss_log";
@@ -400,12 +400,12 @@ public class FileLogger implements GnssListener {
   }
 
   private void logException(String errorMessage, Exception e) {
-    Log.e(GnssContainer.TAG + TAG, errorMessage, e);
+    Log.e(SensorFusionContainer.TAG + TAG, errorMessage, e);
     Toast.makeText(mContext, errorMessage, Toast.LENGTH_LONG).show();
   }
 
   private void logError(String errorMessage) {
-    Log.e(GnssContainer.TAG + TAG, errorMessage);
+    Log.e(SensorFusionContainer.TAG + TAG, errorMessage);
     Toast.makeText(mContext, errorMessage, Toast.LENGTH_LONG).show();
   }
 

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/LoggerFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/LoggerFragment.java
@@ -261,7 +261,7 @@ public class LoggerFragment extends Fragment implements TimerListener {
   }
 
   /**
-   * A facade for UI and Activity related operations that are required for {@link GnssListener}s.
+   * A facade for UI and Activity related operations that are required for {@link SensorFusionListener}s.
    */
   public class UIFragmentComponent {
 

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/MainActivity.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends AppCompatActivity
   private static final int FRAGMENT_INDEX_PLOT = 5;
   private static final String TAG = "MainActivity";
 
-  private GnssContainer mGnssContainer;
+  private SensorFusionContainer mSensorFusionContainer;
   private UiLogger mUiLogger;
   private RealTimePositionVelocityCalculator mRealTimePositionVelocityCalculator;
   private FileLogger mFileLogger;
@@ -124,7 +124,7 @@ public class MainActivity extends AppCompatActivity
 
   @Override
   protected void onDestroy(){
-    mGnssContainer.unregisterAll();
+    mSensorFusionContainer.unregisterAll();
     super.onDestroy();
   }
 
@@ -257,8 +257,8 @@ public class MainActivity extends AppCompatActivity
 
     mFileLogger = new FileLogger(getApplicationContext());
     mAgnssUiLogger = new AgnssUiLogger();
-    mGnssContainer =
-        new GnssContainer(
+    mSensorFusionContainer =
+        new SensorFusionContainer(
             getApplicationContext(),
             mUiLogger,
             mFileLogger,
@@ -266,7 +266,7 @@ public class MainActivity extends AppCompatActivity
             mAgnssUiLogger);
     mFragments = new Fragment[NUMBER_OF_FRAGMENTS];
     SettingsFragment settingsFragment = new SettingsFragment();
-    settingsFragment.setGpsContainer(mGnssContainer);
+    settingsFragment.setGpsContainer(mSensorFusionContainer);
     settingsFragment.setRealTimePositionVelocityCalculator(mRealTimePositionVelocityCalculator);
     settingsFragment.setAutoModeSwitcher(this);
     mFragments[FRAGMENT_INDEX_SETTING] = settingsFragment;
@@ -285,7 +285,7 @@ public class MainActivity extends AppCompatActivity
     mFragments[FRAGMENT_INDEX_MAP] = mapFragment;
 
     AgnssFragment agnssFragment = new AgnssFragment();
-    agnssFragment.setGpsContainer(mGnssContainer);
+    agnssFragment.setGpsContainer(mSensorFusionContainer);
     agnssFragment.setUILogger(mAgnssUiLogger);
     mFragments[FRAGMENT_INDEX_AGNSS] = agnssFragment;
 

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/RealTimePositionVelocityCalculator.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/RealTimePositionVelocityCalculator.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * computed position and velocity solutions are passed to the {@link ResultFragment} to be
  * visualized.
  */
-public class RealTimePositionVelocityCalculator implements GnssListener {
+public class RealTimePositionVelocityCalculator implements SensorFusionListener {
   /** Residual analysis where user disabled residual plots */
   public static final int RESIDUAL_MODE_DISABLED = -1;
 
@@ -93,7 +93,7 @@ public class RealTimePositionVelocityCalculator implements GnssListener {
                   new PseudorangePositionVelocityFromRealTimeEvents();
             } catch (Exception e) {
               Log.e(
-                  GnssContainer.TAG,
+                  SensorFusionContainer.TAG,
                   " Exception in constructing PseudorangePositionFromRealTimeEvents : ",
                   e);
             }
@@ -143,7 +143,7 @@ public class RealTimePositionVelocityCalculator implements GnssListener {
                     (int) (location.getLongitude() * 1E7),
                     (int) (location.getAltitude() * 1E7));
               } catch (Exception e) {
-                Log.e(GnssContainer.TAG, " Exception setting reference location : ", e);
+                Log.e(SensorFusionContainer.TAG, " Exception setting reference location : ", e);
               }
             }
           };
@@ -368,7 +368,7 @@ public class RealTimePositionVelocityCalculator implements GnssListener {
   public void onListenerRegistration(String listener, boolean result) {}
 
   private void logEvent(String tag, String message, int color) {
-    String composedTag = GnssContainer.TAG + tag;
+    String composedTag = SensorFusionContainer.TAG + tag;
     Log.d(composedTag, message);
     logText(tag, message, color);
   }

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/RealTimePositionVelocityCalculator.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/RealTimePositionVelocityCalculator.java
@@ -17,6 +17,7 @@
 package com.google.android.apps.location.gps.gnsslogger;
 
 import android.graphics.Color;
+import android.hardware.SensorEvent;
 import android.location.GnssMeasurementsEvent;
 import android.location.GnssNavigationMessage;
 import android.location.GnssStatus;
@@ -363,6 +364,10 @@ public class RealTimePositionVelocityCalculator implements SensorFusionListener 
 
   @Override
   public void onNmeaReceived(long l, String s) {}
+
+  @Override
+  public void onSensorChanged(SensorEvent event) {
+  }
 
   @Override
   public void onListenerRegistration(String listener, boolean result) {}

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/ResultFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/ResultFragment.java
@@ -90,7 +90,7 @@ public class ResultFragment extends Fragment {
   }
 
   /**
-   * A facade for UI and Activity related operations that are required for {@link GnssListener}s.
+   * A facade for UI and Activity related operations that are required for {@link SensorFusionListener}s.
    */
   public class UIResultComponent {
 

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionContainer.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionContainer.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A container for GPS related API calls, it binds the {@link LocationManager} with {@link UiLogger}
  */
-public class GnssContainer {
+public class SensorFusionContainer {
 
   public static final String TAG = "GnssLogger";
 
@@ -50,7 +50,7 @@ public class GnssContainer {
   private long ttff = 0L;
   private boolean firstTime = true;
 
-  private final List<GnssListener> mLoggers;
+  private final List<SensorFusionListener> mLoggers;
 
   private final LocationManager mLocationManager;
   private final LocationListener mLocationListener =
@@ -59,7 +59,7 @@ public class GnssContainer {
         @Override
         public void onProviderEnabled(String provider) {
           if (mLogLocations) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               if (logger instanceof AgnssUiLogger && !firstTime) {
                 continue;
               }
@@ -71,7 +71,7 @@ public class GnssContainer {
         @Override
         public void onProviderDisabled(String provider) {
           if (mLogLocations) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               if (logger instanceof AgnssUiLogger && !firstTime) {
                 continue;
               }
@@ -84,7 +84,7 @@ public class GnssContainer {
         public void onLocationChanged(Location location) {
           if (firstTime && location.getProvider().equals(LocationManager.GPS_PROVIDER)) {
             if (mLogLocations) {
-              for (GnssListener logger : mLoggers) {
+              for (SensorFusionListener logger : mLoggers) {
                 firstLocationTimeNanos = SystemClock.elapsedRealtimeNanos();
                 ttff = firstLocationTimeNanos - registrationTimeNanos;
                 logger.onTTFFReceived(ttff);
@@ -93,7 +93,7 @@ public class GnssContainer {
             firstTime = false;
           }
           if (mLogLocations) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               if (logger instanceof AgnssUiLogger && !firstTime) {
                 continue;
               }
@@ -105,7 +105,7 @@ public class GnssContainer {
         @Override
         public void onStatusChanged(String provider, int status, Bundle extras) {
           if (mLogLocations) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               logger.onLocationStatusChanged(provider, status, extras);
             }
           }
@@ -117,7 +117,7 @@ public class GnssContainer {
         @Override
         public void onGnssMeasurementsReceived(GnssMeasurementsEvent event) {
           if (mLogMeasurements) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               logger.onGnssMeasurementsReceived(event);
             }
           }
@@ -126,7 +126,7 @@ public class GnssContainer {
         @Override
         public void onStatusChanged(int status) {
           if (mLogMeasurements) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               logger.onGnssMeasurementsStatusChanged(status);
             }
           }
@@ -138,7 +138,7 @@ public class GnssContainer {
         @Override
         public void onGnssNavigationMessageReceived(GnssNavigationMessage event) {
           if (mLogNavigationMessages) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               logger.onGnssNavigationMessageReceived(event);
             }
           }
@@ -147,7 +147,7 @@ public class GnssContainer {
         @Override
         public void onStatusChanged(int status) {
           if (mLogNavigationMessages) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               logger.onGnssNavigationMessageStatusChanged(status);
             }
           }
@@ -167,7 +167,7 @@ public class GnssContainer {
 
         @Override
         public void onSatelliteStatusChanged(GnssStatus status) {
-          for (GnssListener logger : mLoggers) {
+          for (SensorFusionListener logger : mLoggers) {
             logger.onGnssStatusChanged(status);
           }
         }
@@ -178,14 +178,14 @@ public class GnssContainer {
         @Override
         public void onNmeaMessage(String s, long l) {
           if (mLogNmeas) {
-            for (GnssListener logger : mLoggers) {
+            for (SensorFusionListener logger : mLoggers) {
               logger.onNmeaReceived(l, s);
             }
           }
         }
       };
 
-  public GnssContainer(Context context, GnssListener... loggers) {
+  public SensorFusionContainer(Context context, SensorFusionListener... loggers) {
     this.mLoggers = Arrays.asList(loggers);
     mLocationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
   }
@@ -328,7 +328,7 @@ public class GnssContainer {
   }
 
   private void logRegistration(String listener, boolean result) {
-    for (GnssListener logger : mLoggers) {
+    for (SensorFusionListener logger : mLoggers) {
       if (logger instanceof AgnssUiLogger && !firstTime) {
         continue;
       }

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionContainer.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionContainer.java
@@ -24,8 +24,13 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.location.OnNmeaMessageListener;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorManager;
+import android.hardware.SensorEventListener;
 import android.os.Bundle;
 import android.os.SystemClock;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -35,304 +40,339 @@ import java.util.concurrent.TimeUnit;
  */
 public class SensorFusionContainer {
 
-  public static final String TAG = "GnssLogger";
+    public static final String TAG = "GnssLogger";
 
-  private static final long LOCATION_RATE_GPS_MS = TimeUnit.SECONDS.toMillis(1L);
-  private static final long LOCATION_RATE_NETWORK_MS = TimeUnit.SECONDS.toMillis(60L);
+    private static final long LOCATION_RATE_GPS_MS = TimeUnit.SECONDS.toMillis(1L);
+    private static final long LOCATION_RATE_NETWORK_MS = TimeUnit.SECONDS.toMillis(60L);
 
-  private boolean mLogLocations = true;
-  private boolean mLogNavigationMessages = true;
-  private boolean mLogMeasurements = true;
-  private boolean mLogStatuses = true;
-  private boolean mLogNmeas = true;
-  private long registrationTimeNanos = 0L;
-  private long firstLocationTimeNanos = 0L;
-  private long ttff = 0L;
-  private boolean firstTime = true;
+    private boolean mLogLocations = true;
+    private boolean mLogNavigationMessages = true;
+    private boolean mLogMeasurements = true;
+    private boolean mLogStatuses = true;
+    private boolean mLogNmeas = true;
+    private long registrationTimeNanos = 0L;
+    private long firstLocationTimeNanos = 0L;
+    private long ttff = 0L;
+    private boolean firstTime = true;
 
-  private final List<SensorFusionListener> mLoggers;
+    private final List<SensorFusionListener> mLoggers;
 
-  private final LocationManager mLocationManager;
-  private final LocationListener mLocationListener =
-      new LocationListener() {
+    private final SensorManager mSensorManager;
+    private final SensorEventListener mSensorListener =
+            new SensorEventListener() {
+                private long lastUpdate = SystemClock.elapsedRealtimeNanos();
 
-        @Override
-        public void onProviderEnabled(String provider) {
-          if (mLogLocations) {
-            for (SensorFusionListener logger : mLoggers) {
-              if (logger instanceof AgnssUiLogger && !firstTime) {
+                @Override
+                public void onSensorChanged(SensorEvent event) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onSensorChanged(event);
+                    }
+                }
+
+                @Override
+                public void onAccuracyChanged(Sensor sensor, int i) {
+                }
+            };
+
+    private final LocationManager mLocationManager;
+    private final LocationListener mLocationListener =
+            new LocationListener() {
+
+                @Override
+                public void onProviderEnabled(String provider) {
+                    if (mLogLocations) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            if (logger instanceof AgnssUiLogger && !firstTime) {
+                                continue;
+                            }
+                            logger.onProviderEnabled(provider);
+                        }
+                    }
+                }
+
+                @Override
+                public void onProviderDisabled(String provider) {
+                    if (mLogLocations) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            if (logger instanceof AgnssUiLogger && !firstTime) {
+                                continue;
+                            }
+                            logger.onProviderDisabled(provider);
+                        }
+                    }
+                }
+
+                @Override
+                public void onLocationChanged(Location location) {
+                    if (firstTime && location.getProvider().equals(LocationManager.GPS_PROVIDER)) {
+                        if (mLogLocations) {
+                            for (SensorFusionListener logger : mLoggers) {
+                                firstLocationTimeNanos = SystemClock.elapsedRealtimeNanos();
+                                ttff = firstLocationTimeNanos - registrationTimeNanos;
+                                logger.onTTFFReceived(ttff);
+                            }
+                        }
+                        firstTime = false;
+                    }
+                    if (mLogLocations) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            if (logger instanceof AgnssUiLogger && !firstTime) {
+                                continue;
+                            }
+                            logger.onLocationChanged(location);
+                        }
+                    }
+                }
+
+                @Override
+                public void onStatusChanged(String provider, int status, Bundle extras) {
+                    if (mLogLocations) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onLocationStatusChanged(provider, status, extras);
+                        }
+                    }
+                }
+            };
+
+    private final GnssMeasurementsEvent.Callback gnssMeasurementsEventListener =
+            new GnssMeasurementsEvent.Callback() {
+                @Override
+                public void onGnssMeasurementsReceived(GnssMeasurementsEvent event) {
+                    if (mLogMeasurements) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onGnssMeasurementsReceived(event);
+                        }
+                    }
+                }
+
+                @Override
+                public void onStatusChanged(int status) {
+                    if (mLogMeasurements) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onGnssMeasurementsStatusChanged(status);
+                        }
+                    }
+                }
+            };
+
+    private final GnssNavigationMessage.Callback gnssNavigationMessageListener =
+            new GnssNavigationMessage.Callback() {
+                @Override
+                public void onGnssNavigationMessageReceived(GnssNavigationMessage event) {
+                    if (mLogNavigationMessages) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onGnssNavigationMessageReceived(event);
+                        }
+                    }
+                }
+
+                @Override
+                public void onStatusChanged(int status) {
+                    if (mLogNavigationMessages) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onGnssNavigationMessageStatusChanged(status);
+                        }
+                    }
+                }
+            };
+
+    private final GnssStatus.Callback gnssStatusListener =
+            new GnssStatus.Callback() {
+                @Override
+                public void onStarted() {
+                }
+
+                @Override
+                public void onStopped() {
+                }
+
+                @Override
+                public void onFirstFix(int ttff) {
+                }
+
+                @Override
+                public void onSatelliteStatusChanged(GnssStatus status) {
+                    for (SensorFusionListener logger : mLoggers) {
+                        logger.onGnssStatusChanged(status);
+                    }
+                }
+            };
+
+    private final OnNmeaMessageListener nmeaListener =
+            new OnNmeaMessageListener() {
+                @Override
+                public void onNmeaMessage(String s, long l) {
+                    if (mLogNmeas) {
+                        for (SensorFusionListener logger : mLoggers) {
+                            logger.onNmeaReceived(l, s);
+                        }
+                    }
+                }
+            };
+
+    public SensorFusionContainer(Context context, SensorFusionListener... loggers) {
+        this.mLoggers = Arrays.asList(loggers);
+        mLocationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        mSensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+    }
+
+    public LocationManager getLocationManager() {
+        return mLocationManager;
+    }
+
+    public void setLogLocations(boolean value) {
+        mLogLocations = value;
+    }
+
+    public boolean canLogLocations() {
+        return mLogLocations;
+    }
+
+    public void setLogNavigationMessages(boolean value) {
+        mLogNavigationMessages = value;
+    }
+
+    public boolean canLogNavigationMessages() {
+        return mLogNavigationMessages;
+    }
+
+    public void setLogMeasurements(boolean value) {
+        mLogMeasurements = value;
+    }
+
+    public boolean canLogMeasurements() {
+        return mLogMeasurements;
+    }
+
+    public void setLogStatuses(boolean value) {
+        mLogStatuses = value;
+    }
+
+    public boolean canLogStatuses() {
+        return mLogStatuses;
+    }
+
+    public void setLogNmeas(boolean value) {
+        mLogNmeas = value;
+    }
+
+    public boolean canLogNmeas() {
+        return mLogNmeas;
+    }
+
+    public void registerLocation() {
+        boolean isGpsProviderEnabled = mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        if (isGpsProviderEnabled) {
+            mLocationManager.requestLocationUpdates(
+                    LocationManager.NETWORK_PROVIDER,
+                    LOCATION_RATE_NETWORK_MS,
+                    0.0f /* minDistance */,
+                    mLocationListener);
+            mLocationManager.requestLocationUpdates(
+                    LocationManager.GPS_PROVIDER,
+                    LOCATION_RATE_GPS_MS,
+                    0.0f /* minDistance */,
+                    mLocationListener);
+        }
+        logRegistration("LocationUpdates", isGpsProviderEnabled);
+    }
+
+    public void unregisterLocation() {
+        mLocationManager.removeUpdates(mLocationListener);
+    }
+
+    public void registerSensors() {
+        mSensorManager.registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
+                SensorManager.SENSOR_DELAY_FASTEST);
+        mSensorManager.registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE), SensorManager.SENSOR_DELAY_FASTEST);
+        mSensorManager.registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD), SensorManager.SENSOR_DELAY_FASTEST);
+        mSensorManager.registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE), SensorManager.SENSOR_DELAY_FASTEST);
+        mSensorManager.registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR), SensorManager.SENSOR_DELAY_FASTEST);
+        mSensorManager.registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION), SensorManager.SENSOR_DELAY_FASTEST);
+    }
+
+    public void unregisterSensors() {
+        mSensorManager.unregisterListener(mSensorListener);
+    }
+
+    public void registerSingleNetworkLocation() {
+        boolean isNetworkProviderEnabled =
+                mLocationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+        if (isNetworkProviderEnabled) {
+            mLocationManager.requestSingleUpdate(
+                    LocationManager.NETWORK_PROVIDER, mLocationListener, null);
+        }
+        logRegistration("LocationUpdates", isNetworkProviderEnabled);
+    }
+
+    public void registerSingleGpsLocation() {
+        boolean isGpsProviderEnabled = mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        if (isGpsProviderEnabled) {
+            this.firstTime = true;
+            registrationTimeNanos = SystemClock.elapsedRealtimeNanos();
+            mLocationManager.requestSingleUpdate(LocationManager.GPS_PROVIDER, mLocationListener, null);
+        }
+        logRegistration("LocationUpdates", isGpsProviderEnabled);
+    }
+
+    public void registerMeasurements() {
+        logRegistration(
+                "GnssMeasurements",
+                mLocationManager.registerGnssMeasurementsCallback(gnssMeasurementsEventListener));
+    }
+
+    public void unregisterMeasurements() {
+        mLocationManager.unregisterGnssMeasurementsCallback(gnssMeasurementsEventListener);
+    }
+
+    public void registerNavigation() {
+        logRegistration(
+                "GpsNavigationMessage",
+                mLocationManager.registerGnssNavigationMessageCallback(gnssNavigationMessageListener));
+    }
+
+    public void unregisterNavigation() {
+        mLocationManager.unregisterGnssNavigationMessageCallback(gnssNavigationMessageListener);
+    }
+
+    public void registerGnssStatus() {
+        logRegistration("GnssStatus", mLocationManager.registerGnssStatusCallback(gnssStatusListener));
+    }
+
+    public void unregisterGpsStatus() {
+        mLocationManager.unregisterGnssStatusCallback(gnssStatusListener);
+    }
+
+    public void registerNmea() {
+        logRegistration("Nmea", mLocationManager.addNmeaListener(nmeaListener));
+    }
+
+    public void unregisterNmea() {
+        mLocationManager.removeNmeaListener(nmeaListener);
+    }
+
+    public void registerAll() {
+        registerLocation();
+        registerMeasurements();
+        registerNavigation();
+        registerGnssStatus();
+        registerNmea();
+    }
+
+    public void unregisterAll() {
+        unregisterLocation();
+        unregisterMeasurements();
+        unregisterNavigation();
+        unregisterGpsStatus();
+        unregisterNmea();
+    }
+
+    private void logRegistration(String listener, boolean result) {
+        for (SensorFusionListener logger : mLoggers) {
+            if (logger instanceof AgnssUiLogger && !firstTime) {
                 continue;
-              }
-              logger.onProviderEnabled(provider);
             }
-          }
+            logger.onListenerRegistration(listener, result);
         }
-
-        @Override
-        public void onProviderDisabled(String provider) {
-          if (mLogLocations) {
-            for (SensorFusionListener logger : mLoggers) {
-              if (logger instanceof AgnssUiLogger && !firstTime) {
-                continue;
-              }
-              logger.onProviderDisabled(provider);
-            }
-          }
-        }
-
-        @Override
-        public void onLocationChanged(Location location) {
-          if (firstTime && location.getProvider().equals(LocationManager.GPS_PROVIDER)) {
-            if (mLogLocations) {
-              for (SensorFusionListener logger : mLoggers) {
-                firstLocationTimeNanos = SystemClock.elapsedRealtimeNanos();
-                ttff = firstLocationTimeNanos - registrationTimeNanos;
-                logger.onTTFFReceived(ttff);
-              }
-            }
-            firstTime = false;
-          }
-          if (mLogLocations) {
-            for (SensorFusionListener logger : mLoggers) {
-              if (logger instanceof AgnssUiLogger && !firstTime) {
-                continue;
-              }
-              logger.onLocationChanged(location);
-            }
-          }
-        }
-
-        @Override
-        public void onStatusChanged(String provider, int status, Bundle extras) {
-          if (mLogLocations) {
-            for (SensorFusionListener logger : mLoggers) {
-              logger.onLocationStatusChanged(provider, status, extras);
-            }
-          }
-        }
-      };
-
-  private final GnssMeasurementsEvent.Callback gnssMeasurementsEventListener =
-      new GnssMeasurementsEvent.Callback() {
-        @Override
-        public void onGnssMeasurementsReceived(GnssMeasurementsEvent event) {
-          if (mLogMeasurements) {
-            for (SensorFusionListener logger : mLoggers) {
-              logger.onGnssMeasurementsReceived(event);
-            }
-          }
-        }
-
-        @Override
-        public void onStatusChanged(int status) {
-          if (mLogMeasurements) {
-            for (SensorFusionListener logger : mLoggers) {
-              logger.onGnssMeasurementsStatusChanged(status);
-            }
-          }
-        }
-      };
-
-  private final GnssNavigationMessage.Callback gnssNavigationMessageListener =
-      new GnssNavigationMessage.Callback() {
-        @Override
-        public void onGnssNavigationMessageReceived(GnssNavigationMessage event) {
-          if (mLogNavigationMessages) {
-            for (SensorFusionListener logger : mLoggers) {
-              logger.onGnssNavigationMessageReceived(event);
-            }
-          }
-        }
-
-        @Override
-        public void onStatusChanged(int status) {
-          if (mLogNavigationMessages) {
-            for (SensorFusionListener logger : mLoggers) {
-              logger.onGnssNavigationMessageStatusChanged(status);
-            }
-          }
-        }
-      };
-
-  private final GnssStatus.Callback gnssStatusListener =
-      new GnssStatus.Callback() {
-        @Override
-        public void onStarted() {}
-
-        @Override
-        public void onStopped() {}
-
-        @Override
-        public void onFirstFix(int ttff) {}
-
-        @Override
-        public void onSatelliteStatusChanged(GnssStatus status) {
-          for (SensorFusionListener logger : mLoggers) {
-            logger.onGnssStatusChanged(status);
-          }
-        }
-      };
-
-  private final OnNmeaMessageListener nmeaListener =
-      new OnNmeaMessageListener() {
-        @Override
-        public void onNmeaMessage(String s, long l) {
-          if (mLogNmeas) {
-            for (SensorFusionListener logger : mLoggers) {
-              logger.onNmeaReceived(l, s);
-            }
-          }
-        }
-      };
-
-  public SensorFusionContainer(Context context, SensorFusionListener... loggers) {
-    this.mLoggers = Arrays.asList(loggers);
-    mLocationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-  }
-
-  public LocationManager getLocationManager() {
-    return mLocationManager;
-  }
-
-  public void setLogLocations(boolean value) {
-    mLogLocations = value;
-  }
-
-  public boolean canLogLocations() {
-    return mLogLocations;
-  }
-
-  public void setLogNavigationMessages(boolean value) {
-    mLogNavigationMessages = value;
-  }
-
-  public boolean canLogNavigationMessages() {
-    return mLogNavigationMessages;
-  }
-
-  public void setLogMeasurements(boolean value) {
-    mLogMeasurements = value;
-  }
-
-  public boolean canLogMeasurements() {
-    return mLogMeasurements;
-  }
-
-  public void setLogStatuses(boolean value) {
-    mLogStatuses = value;
-  }
-
-  public boolean canLogStatuses() {
-    return mLogStatuses;
-  }
-
-  public void setLogNmeas(boolean value) {
-    mLogNmeas = value;
-  }
-
-  public boolean canLogNmeas() {
-    return mLogNmeas;
-  }
-
-  public void registerLocation() {
-    boolean isGpsProviderEnabled = mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-    if (isGpsProviderEnabled) {
-      mLocationManager.requestLocationUpdates(
-          LocationManager.NETWORK_PROVIDER,
-          LOCATION_RATE_NETWORK_MS,
-          0.0f /* minDistance */,
-          mLocationListener);
-      mLocationManager.requestLocationUpdates(
-          LocationManager.GPS_PROVIDER,
-          LOCATION_RATE_GPS_MS,
-          0.0f /* minDistance */,
-          mLocationListener);
     }
-    logRegistration("LocationUpdates", isGpsProviderEnabled);
-  }
-
-  public void registerSingleNetworkLocation() {
-    boolean isNetworkProviderEnabled =
-        mLocationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-    if (isNetworkProviderEnabled) {
-      mLocationManager.requestSingleUpdate(
-          LocationManager.NETWORK_PROVIDER, mLocationListener, null);
-    }
-    logRegistration("LocationUpdates", isNetworkProviderEnabled);
-  }
-
-  public void registerSingleGpsLocation() {
-    boolean isGpsProviderEnabled = mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-    if (isGpsProviderEnabled) {
-      this.firstTime = true;
-      registrationTimeNanos = SystemClock.elapsedRealtimeNanos();
-      mLocationManager.requestSingleUpdate(LocationManager.GPS_PROVIDER, mLocationListener, null);
-    }
-    logRegistration("LocationUpdates", isGpsProviderEnabled);
-  }
-
-  public void unregisterLocation() {
-    mLocationManager.removeUpdates(mLocationListener);
-  }
-
-  public void registerMeasurements() {
-    logRegistration(
-        "GnssMeasurements",
-        mLocationManager.registerGnssMeasurementsCallback(gnssMeasurementsEventListener));
-  }
-
-  public void unregisterMeasurements() {
-    mLocationManager.unregisterGnssMeasurementsCallback(gnssMeasurementsEventListener);
-  }
-
-  public void registerNavigation() {
-    logRegistration(
-        "GpsNavigationMessage",
-        mLocationManager.registerGnssNavigationMessageCallback(gnssNavigationMessageListener));
-  }
-
-  public void unregisterNavigation() {
-    mLocationManager.unregisterGnssNavigationMessageCallback(gnssNavigationMessageListener);
-  }
-
-  public void registerGnssStatus() {
-    logRegistration("GnssStatus", mLocationManager.registerGnssStatusCallback(gnssStatusListener));
-  }
-
-  public void unregisterGpsStatus() {
-    mLocationManager.unregisterGnssStatusCallback(gnssStatusListener);
-  }
-
-  public void registerNmea() {
-    logRegistration("Nmea", mLocationManager.addNmeaListener(nmeaListener));
-  }
-
-  public void unregisterNmea() {
-    mLocationManager.removeNmeaListener(nmeaListener);
-  }
-
-  public void registerAll() {
-    registerLocation();
-    registerMeasurements();
-    registerNavigation();
-    registerGnssStatus();
-    registerNmea();
-  }
-
-  public void unregisterAll() {
-    unregisterLocation();
-    unregisterMeasurements();
-    unregisterNavigation();
-    unregisterGpsStatus();
-    unregisterNmea();
-  }
-
-  private void logRegistration(String listener, boolean result) {
-    for (SensorFusionListener logger : mLoggers) {
-      if (logger instanceof AgnssUiLogger && !firstTime) {
-        continue;
-      }
-      logger.onListenerRegistration(listener, result);
-    }
-  }
 }

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionListener.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionListener.java
@@ -22,6 +22,7 @@ import android.location.GnssStatus;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.OnNmeaMessageListener;
+import android.hardware.SensorEvent;
 import android.os.Bundle;
 
 /**  A class representing an interface for logging GPS information. */
@@ -49,6 +50,7 @@ public interface SensorFusionListener {
   /** @see GnssStatus.Callback#onSatelliteStatusChanged(GnssStatus) */
   void onGnssStatusChanged(GnssStatus gnssStatus);
   /** Called when the listener is registered to listen to GNSS events */
+  void onSensorChanged(SensorEvent event);
   void onListenerRegistration(String listener, boolean result);
   /** @see OnNmeaMessageListener#onNmeaMessage(String, long) */
   void onNmeaReceived(long l, String s);

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionListener.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SensorFusionListener.java
@@ -25,7 +25,7 @@ import android.location.OnNmeaMessageListener;
 import android.os.Bundle;
 
 /**  A class representing an interface for logging GPS information. */
-public interface GnssListener {
+public interface SensorFusionListener {
 
   /** @see LocationListener#onProviderEnabled(String) */
   void onProviderEnabled(String provider);

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SettingsFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SettingsFragment.java
@@ -213,8 +213,10 @@ public class SettingsFragment extends Fragment {
                   public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                       if (isChecked) {
                           registerImuLabel.setText("Switch is ON");
+                          mSensorContainer.registerSensors();
                       } else {
                           registerImuLabel.setText("Switch is OFF");
+                          mSensorContainer.unregisterSensors();
                       }
                   }
               });

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SettingsFragment.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/SettingsFragment.java
@@ -56,7 +56,7 @@ public class SettingsFragment extends Fragment {
   /** Key in the {@link SharedPreferences} indicating whether auto-scroll has been enabled */
   protected static String PREFERENCE_KEY_AUTO_SCROLL =  "autoScroll";
 
-  private GnssContainer mGpsContainer;
+  private SensorFusionContainer mSensorContainer;
   private HelpDialog helpDialog;
 
   /**
@@ -73,8 +73,8 @@ public class SettingsFragment extends Fragment {
   /** {@link GroundTruthModeSwitcher} to receive update from AR result broadcast */
   private GroundTruthModeSwitcher mModeSwitcher;
 
-  public void setGpsContainer(GnssContainer value) {
-    mGpsContainer = value;
+  public void setGpsContainer(SensorFusionContainer value) {
+    mSensorContainer = value;
   }
 
   /** Set up {@link MainActivity} to receive update from AR result broadcast */
@@ -106,10 +106,10 @@ public class SettingsFragment extends Fragment {
           public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 
             if (isChecked) {
-              mGpsContainer.registerLocation();
+              mSensorContainer.registerLocation();
               registerLocationLabel.setText("Switch is ON");
             } else {
-              mGpsContainer.unregisterLocation();
+              mSensorContainer.unregisterLocation();
               registerLocationLabel.setText("Switch is OFF");
             }
           }
@@ -128,10 +128,10 @@ public class SettingsFragment extends Fragment {
           public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 
             if (isChecked) {
-              mGpsContainer.registerMeasurements();
+              mSensorContainer.registerMeasurements();
               registerMeasurementsLabel.setText("Switch is ON");
             } else {
-              mGpsContainer.unregisterMeasurements();
+              mSensorContainer.unregisterMeasurements();
               registerMeasurementsLabel.setText("Switch is OFF");
             }
           }
@@ -150,10 +150,10 @@ public class SettingsFragment extends Fragment {
           public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 
             if (isChecked) {
-              mGpsContainer.registerNavigation();
+              mSensorContainer.registerNavigation();
               registerNavigationLabel.setText("Switch is ON");
             } else {
-              mGpsContainer.unregisterNavigation();
+              mSensorContainer.unregisterNavigation();
               registerNavigationLabel.setText("Switch is OFF");
             }
           }
@@ -172,10 +172,10 @@ public class SettingsFragment extends Fragment {
           public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 
             if (isChecked) {
-              mGpsContainer.registerGnssStatus();
+              mSensorContainer.registerGnssStatus();
               registerGpsStatusLabel.setText("Switch is ON");
             } else {
-              mGpsContainer.unregisterGpsStatus();
+              mSensorContainer.unregisterGpsStatus();
               registerGpsStatusLabel.setText("Switch is OFF");
             }
           }
@@ -193,15 +193,34 @@ public class SettingsFragment extends Fragment {
           public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 
             if (isChecked) {
-              mGpsContainer.registerNmea();
+              mSensorContainer.registerNmea();
               registerNmeaLabel.setText("Switch is ON");
             } else {
-              mGpsContainer.unregisterNmea();
+              mSensorContainer.unregisterNmea();
               registerNmeaLabel.setText("Switch is OFF");
             }
           }
         });
-    final Switch autoScroll = (Switch) view.findViewById(R.id.auto_scroll_on);
+
+      final Switch registerImu = (Switch) view.findViewById(R.id.register_imu);
+      final TextView registerImuLabel = (TextView) view.findViewById(R.id.register_imu_label);
+      //set the switch to OFF
+      registerImu.setChecked(false);
+      registerImuLabel.setText("Switch is OFF");
+      registerImu.setOnCheckedChangeListener(
+              new OnCheckedChangeListener() {
+                  @Override
+                  public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                      if (isChecked) {
+                          registerImuLabel.setText("Switch is ON");
+                      } else {
+                          registerImuLabel.setText("Switch is OFF");
+                      }
+                  }
+              });
+
+
+      final Switch autoScroll = (Switch) view.findViewById(R.id.auto_scroll_on);
     final TextView turnOnAutoScroll = (TextView) view.findViewById(R.id.turn_on_auto_scroll);
     turnOnAutoScroll.setText("Switch is OFF");
     autoScroll.setOnCheckedChangeListener(
@@ -356,7 +375,7 @@ public class SettingsFragment extends Fragment {
     TextView swInfo = (TextView) view.findViewById(R.id.sw_info);
 
     java.lang.reflect.Method method;
-    LocationManager locationManager = mGpsContainer.getLocationManager();
+    LocationManager locationManager = mSensorContainer.getLocationManager();
     try {
       method = locationManager.getClass().getMethod("getGnssYearOfHardware");
       int hwYear = (int) method.invoke(locationManager);
@@ -386,7 +405,7 @@ public class SettingsFragment extends Fragment {
   }
 
   private void logException(String errorMessage, Exception e) {
-    Log.e(GnssContainer.TAG + TAG, errorMessage, e);
+    Log.e(SensorFusionContainer.TAG + TAG, errorMessage, e);
     Toast.makeText(getContext(), errorMessage, Toast.LENGTH_LONG).show();
   }
 }

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/UiLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/UiLogger.java
@@ -33,7 +33,7 @@ import java.text.DecimalFormat;
  * A class representing a UI logger for the application. Its responsibility is show information in
  * the UI.
  */
-public class UiLogger implements GnssListener {
+public class UiLogger implements SensorFusionListener {
 
   private static final int USED_COLOR = Color.rgb(0x4a, 0x5f, 0x70);
 
@@ -281,7 +281,7 @@ public class UiLogger implements GnssListener {
   }
 
   private void logEvent(String tag, String message, int color) {
-    String composedTag = GnssContainer.TAG + tag;
+    String composedTag = SensorFusionContainer.TAG + tag;
     Log.d(composedTag, message);
     logText(tag, message, color);
   }

--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/UiLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/UiLogger.java
@@ -24,6 +24,7 @@ import android.location.GnssNavigationMessage;
 import android.location.GnssStatus;
 import android.location.Location;
 import android.location.LocationProvider;
+import android.hardware.SensorEvent;
 import android.os.Bundle;
 import android.util.Log;
 import com.google.android.apps.location.gps.gnsslogger.LoggerFragment.UIFragmentComponent;
@@ -257,6 +258,10 @@ public class UiLogger implements SensorFusionListener {
   @Override
   public void onNmeaReceived(long timestamp, String s) {
     logNmeaEvent(String.format("onNmeaReceived: timestamp=%d, %s", timestamp, s));
+  }
+
+  @Override
+  public void onSensorChanged(SensorEvent event) {
   }
 
   @Override

--- a/GNSSLogger/app/src/main/res/layout/fragment_main.xml
+++ b/GNSSLogger/app/src/main/res/layout/fragment_main.xml
@@ -32,23 +32,25 @@
   </LinearLayout>
 
   <LinearLayout
-      android:orientation="horizontal"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
     <TextView
+        android:id="@+id/register_measurement_label"
         android:layout_width="0dp"
-        android:layout_weight="1"
         android:layout_height="wrap_content"
-        android:textStyle="bold"
         android:layout_marginTop="15dp"
-        android:id="@+id/register_measurement_label" />
+        android:layout_weight="1"
+        android:textStyle="bold" />
+
     <Switch
-        android:layout_width="0dp"
-        android:layout_weight="1"
-        android:layout_height="wrap_content"
         android:id="@+id/register_measurements"
-        android:singleLine="true"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="15dp"
+        android:layout_weight="1"
+        android:singleLine="true"
         android:text="@string/measurements_label" />
   </LinearLayout>
 
@@ -114,6 +116,30 @@
         android:singleLine="true"
         android:layout_marginTop="15dp"
         android:text="@string/nmea_label" />
+  </LinearLayout>
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/register_imu_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:layout_weight="1"
+        android:text="@string/register_imu_label"
+        android:textStyle="bold" />
+
+    <Switch
+        android:id="@+id/register_imu"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:layout_weight="1"
+        android:singleLine="true"
+        android:text="@string/imu_label" />
   </LinearLayout>
 
   <LinearLayout

--- a/GNSSLogger/app/src/main/res/values/strings.xml
+++ b/GNSSLogger/app/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
         <xliff:g id="historyAverage">%s</xliff:g></string>
     <string name="satellite_number_sum_hint">Total Number of Visible Satellites:
         <xliff:g id="totalNumber">%d</xliff:g></string>
+    <string name="register_imu_label">register_imu_label</string>
+    <string name="imu_label">IMU</string>
     <string-array name="constellation_arrays">
         <item>All</item>
         <item>GPS</item>


### PR DESCRIPTION
I added listeners for the accelerometer, gyroscope, magnetometer, pressure, rotation vector, and linear acceleration sensors. This provides users with the same data used in Google Play's Fused Location Provider so they can use these additional readings in combination with raw GNSS data. The IMU update rate is too high to output values to the UI logger for longer than a few seconds without bogging it down, so I only implemented the onSensorChanged method for the file logger.