### PR TITLE
fix: Apply bitmask to determine if ADR is valid

### DIFF
--- a/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/UiLogger.java
+++ b/GNSSLogger/app/src/main/java/com/google/android/apps/location/gps/gnsslogger/UiLogger.java
@@ -178,7 +178,7 @@ public class UiLogger implements MeasurementListener {
             "PseudorangeRateUncertaintyMetersPerSeconds",
             numberFormat.format(measurement.getPseudorangeRateUncertaintyMetersPerSecond())));
 
-    if (measurement.getAccumulatedDeltaRangeState() != 0) {
+    if (measurement.getAccumulatedDeltaRangeState() != GnssMeasurement.ADR_STATE_UNKNOWN) {
       builder.append(
           String.format(
               format, "AccumulatedDeltaRangeState", measurement.getAccumulatedDeltaRangeState()));

--- a/GNSSLogger/pseudorange/src/main/java/com/google/location/lbs/gnss/gps/pseudorange/PseudorangePositionVelocityFromRealTimeEvents.java
+++ b/GNSSLogger/pseudorange/src/main/java/com/google/location/lbs/gnss/gps/pseudorange/PseudorangePositionVelocityFromRealTimeEvents.java
@@ -48,7 +48,6 @@ public class PseudorangePositionVelocityFromRealTimeEvents {
   private static final double SECONDS_PER_NANO = 1.0e-9;
   private static final int TOW_DECODED_MEASUREMENT_STATE_BIT = 3;
   /** Average signal travel time from GPS satellite and earth */
-  private static final int VALID_ACCUMULATED_DELTA_RANGE_STATE = 1;
   private static final int MINIMUM_NUMBER_OF_USEFUL_SATELLITES = 4;
   private static final int C_TO_N0_THRESHOLD_DB_HZ = 18;
 
@@ -139,7 +138,7 @@ public class PseudorangePositionVelocityFromRealTimeEvents {
             new GpsMeasurement(
                 (long) mArrivalTimeSinceGPSWeekNs,
                 measurement.getAccumulatedDeltaRangeMeters(),
-                measurement.getAccumulatedDeltaRangeState() == VALID_ACCUMULATED_DELTA_RANGE_STATE,
+                isAccumulatedDeltaRangeStateValid(measurement.getAccumulatedDeltaRangeState()),
                 measurement.getPseudorangeRateMetersPerSecond(),
                 measurement.getCn0DbHz(),
                 measurement.getAccumulatedDeltaRangeUncertaintyMeters(),
@@ -415,6 +414,19 @@ public class PseudorangePositionVelocityFromRealTimeEvents {
       }
     }
     return useNavMessageFromSupl;
+  }
+
+  /**
+   * Returns the result of the GnssMeasurement.ADR_STATE_VALID bitmask being applied to the
+   * AccumulatedDeltaRangeState from a GnssMeasurement - true if the ADR state is valid,
+   * false if it is not
+   * @param accumulatedDeltaRangeState accumulatedDeltaRangeState from GnssMeasurement
+   * @return the result of the GnssMeasurement.ADR_STATE_VALID bitmask being applied to the
+   *      * AccumulatedDeltaRangeState of the given GnssMeasurement - true if the ADR state is valid,
+   *      * false if it is not
+   */
+  private static boolean isAccumulatedDeltaRangeStateValid(int accumulatedDeltaRangeState) {
+    return (GnssMeasurement.ADR_STATE_VALID & accumulatedDeltaRangeState) == GnssMeasurement.ADR_STATE_VALID;
   }
 
   /**


### PR DESCRIPTION
GnssLogger currently uses a test of equality to `1` (`GnssMeasurement.ADR_STATE_VALID`) for `GnssMeasurement.getAccumulatedDeltaRangeState()` to determine if the ADR is valid for a particular measurement.

This no longer works with newer devices >= API 28, as the ADR is now a bitmask of the various constants listed at:
https://developer.android.com/reference/android/location/GnssMeasurement#constants_1

For example, the ADR state can be both `ADR_STATE_HALF_CYCLE_RESOLVED` logical OR'd with `ADR_STATE_VALID`, with gives you `1001` in binary or `9` in decimal. So this is a valid ADR state, but 
is not equal to `1`.

You can see these valid ADR state values that aren't equal to `1` in the data from the Google "Smartphone Decimeter Challenge" here:
https://www.kaggle.com/google/android-smartphones-high-accuracy-datasets

This PR changes the GnssLogger code to correctly apply the bitmask to the `GnssMeasurement.getAccumulatedDeltaRangeState()` value to determine if it is a valid ADR state.

It also substitutes a check for an unknown ADR state by using the constant `GnssMeasurement.ADR_STATE_UNKNOWN` instead of just `0`. Note that Lint incorrectly flags the use of this constant currently as an error - I've opened an issue on the Google issue tracker here about this:
https://issuetracker.google.com/issues/174553586